### PR TITLE
updated post route for accountgroups

### DIFF
--- a/lib/accountgroup/accountgroup.routes.js
+++ b/lib/accountgroup/accountgroup.routes.js
@@ -68,7 +68,7 @@ module.exports = {
 
       {
        method: 'POST',
-       path: '/accountgroup/group/{id}',
+       path: '/accountgroup',
        config: {
          auth: 'jwt',
          handler: controllers.createAccountsFromGroup,


### PR DESCRIPTION
https://trello.com/c/0efprbli/58-update-an-accoutgroup-post-route-so-that-it-does-not-take-in-an-id-in-the-url